### PR TITLE
fix(circleci): correct unary operator error in reviewdog script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Run reviewdog only on pull requests
           command: |
-            if [ "${CIRCLE_PULL_REQUEST##*/}" != ""]; then
+            if [ "${CIRCLE_PULL_REQUEST##*/}" != "" ]; then
                 npm run lint 2>&1 | ./bin/reviewdog -f=eslint -reporter=github-pr-review
             else
                 echo "Not a pull request build. Skipping reviewdog."


### PR DESCRIPTION
### fix/unary-operator-error

#### Summary
---

- fix(circleci): correct unary operator error in reviewdog script
- closes #18

#### Why it is good for the code?
---

This change corrects the unary operator error in the reviewdog script by adding a space before the closing bracket in the condition check. This ensures that the script runs correctly during pull request builds.