### PR TITLE
fix: email service

### DIFF
--- a/src/api/components/auth/controllers/auth.controller.js
+++ b/src/api/components/auth/controllers/auth.controller.js
@@ -69,7 +69,7 @@ export const sendPasswordReset = async (req, res, next) => {
 
         if (user) {
             const passwordResetObj = await PasswordResetToken.generate(user);
-            await emailService.sendPasswordReset(passwordResetObj);
+            await emailService.sendPasswordReset(passwordResetObj, user);
             res.status(httpStatus.OK);
             return res.json({message: 'Password reset email sent'});
         }
@@ -123,7 +123,7 @@ export const sendEmailVerification = async (req, res, next) => {
         const user = await User.findOne({ where: { email } });
         if (user) {
             const emailVerificationToken = await EmailVerificationToken.generate(user);
-            await emailService.sendVerificationEmail(emailVerificationToken);
+            await emailService.sendVerificationEmail(emailVerificationToken, user);
             res.status(httpStatus.OK);
             return res.json({ message: 'Email verification sent' });
         }

--- a/src/api/components/email/services/email.service.js
+++ b/src/api/components/email/services/email.service.js
@@ -1,9 +1,13 @@
 import nodemailer from 'nodemailer';
 import pug from 'pug';
 import path from 'path';
+import {fileURLToPath} from 'url';
 import httpStatus from "http-status";
 import APIError from '../../../utils/api-error.js';
 import {frontend_url, mailgun} from '../../../config/vars.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const transporter = nodemailer.createTransport({
     service: 'Mailgun',
@@ -23,9 +27,8 @@ transporter.verify((error) => {
     }
 });
 
-export const sendPasswordReset = async (passwordResetObject) => {
+export const sendPasswordReset = async (passwordResetObject, user) => {
     try {
-        const { user } = passwordResetObject;
         const templatePath = path.join(__dirname, '../templates', 'passwordReset.pug');
         const html = pug.renderFile(templatePath, {
             resetLink: `${frontend_url}/reset-password?token=${passwordResetObject.token}`,
@@ -47,9 +50,8 @@ export const sendPasswordReset = async (passwordResetObject) => {
     }
 };
 
-export const sendVerificationEmail = async (verificationObject) => {
+export const sendVerificationEmail = async (verificationObject, user) => {
     try {
-        const { user } = verificationObject;
         const templatePath = path.join(__dirname, '../templates', 'emailVerification.pug');
         const html = pug.renderFile(templatePath, {
             verificationLink: `${frontend_url}/verify-email?token=${encodeURIComponent(verificationObject.token)}`,


### PR DESCRIPTION
### About this pull request.
The user object is passed to the email service methods to avoid TypeError: Cannot read properties of undefined (reading 'email') errors.

The user parameter is added to the email service functions to ensure that the user object is available and used correctly.